### PR TITLE
Provide optional color output for nodes

### DIFF
--- a/iotlabaggregator/serial.py
+++ b/iotlabaggregator/serial.py
@@ -67,25 +67,41 @@ import logging
 import sys
 import argparse
 
-try:
-    from colorama import init, Fore
-    init()
-    COLOR = [Fore.BLACK, Fore.RED, Fore.GREEN, Fore.YELLOW, Fore.BLUE,
-             Fore.MAGENTA, Fore.CYAN, Fore.WHITE]
-    COLOR_RESET = Fore.RESET
-
-    def color_idx(s):
-        return sum(ord(c) for c in s)
-except ImportError:
-    COLOR = ['']
-    COLOR_RESET = ''
-
-    def color_idx(s):
-        return 0
 
 from iotlabcli.parser import common as common_parser
 
 from iotlabaggregator import connections, common, LOG_FMT
+
+try:
+    import colorama  # pylint:disable=import-error
+    HAS_COLOR = True
+except ImportError:
+    HAS_COLOR = False
+
+
+# Declare color specific functions
+if HAS_COLOR:
+    colorama.init()
+    _COLOR = [colorama.Fore.BLACK, colorama.Fore.RED,
+              colorama.Fore.GREEN, colorama.Fore.YELLOW,
+              colorama.Fore.BLUE, colorama.Fore.MAGENTA,
+              colorama.Fore.CYAN, colorama.Fore.WHITE]
+    COLOR_RESET = str(colorama.Fore.RESET)
+
+    def _color_hash(string):
+        """Return a hash of the string."""
+        return sum(ord(c) for c in string)
+
+    def color_str(string):
+        """Return color string character for identifier."""
+        color_idx = _color_hash(string) % len(_COLOR)
+        return str(_COLOR[color_idx])
+else:
+    COLOR_RESET = ''
+
+    def color_str(_):
+        """No color."""
+        return ''
 
 
 class SerialConnection(connections.Connection):  # pylint:disable=R0903,R0904
@@ -105,8 +121,9 @@ class SerialConnection(connections.Connection):  # pylint:disable=R0903,R0904
     logger.setLevel(logging.INFO)
     logger.addHandler(_line_logger)
 
-    def __init__(self, hostname, aggregator,
-                 print_lines=False, line_handler=None):
+    def __init__(self,  # pylint:disable=too-many-arguments
+                 hostname, aggregator,
+                 print_lines=False, line_handler=None, color=False):
         super(SerialConnection, self).__init__(hostname, aggregator)
 
         self.line_handler = common.Event()
@@ -114,6 +131,11 @@ class SerialConnection(connections.Connection):  # pylint:disable=R0903,R0904
             self.line_handler.append(self.print_line)
         if line_handler:
             self.line_handler.append(line_handler)
+
+        self.fmt = '%s;%s'
+        if color:
+            self.fmt = '%s%s%s' % (color_str(self.hostname),
+                                   self.fmt, COLOR_RESET)
 
     def handle_data(self, data):
         """ Print the data received line by line """
@@ -131,8 +153,7 @@ class SerialConnection(connections.Connection):  # pylint:disable=R0903,R0904
 
     def print_line(self, identifier, line):
         """ Print one line prefixed by id in format: """
-        self.logger.info("%s%s;%s%s", COLOR[color_idx(identifier) % len(COLOR)],
-                         identifier, line, COLOR_RESET)
+        self.logger.info(self.fmt, identifier, line)
 
 
 class SerialAggregator(connections.Aggregator):
@@ -145,6 +166,14 @@ class SerialAggregator(connections.Aggregator):
         '--with-a8', action='store_true',
         help=('redirect open-a8 serial port. ' +
               '`/etc/init.d/serial_redirection` must be running on the nodes'))
+
+    # Add 'opts.color' no error if no available
+    parser.set_defaults(color=False)
+    if HAS_COLOR:
+        parser.add_argument(
+            '--color', action='store_true', default=False,
+            help='Add color to node lines.',
+        )
 
     @staticmethod
     def select_nodes(opts):
@@ -252,7 +281,8 @@ def main(args=None):
         # Parse arguments
         nodes_list = SerialAggregator.select_nodes(opts)
         # Run the aggregator
-        with SerialAggregator(nodes_list, print_lines=True) as aggregator:
+        with SerialAggregator(nodes_list, print_lines=True,
+                              color=opts.color) as aggregator:
             aggregator.run()
     except (ValueError, RuntimeError) as err:
         sys.stderr.write("%s\n" % err)

--- a/iotlabaggregator/serial.py
+++ b/iotlabaggregator/serial.py
@@ -67,6 +67,22 @@ import logging
 import sys
 import argparse
 
+try:
+    from colorama import init, Fore
+    init()
+    COLOR = [Fore.BLACK, Fore.RED, Fore.GREEN, Fore.YELLOW, Fore.BLUE,
+             Fore.MAGENTA, Fore.CYAN, Fore.WHITE]
+    COLOR_RESET = Fore.RESET
+
+    def color_idx(s):
+        return sum(ord(c) for c in s)
+except ImportError:
+    COLOR = ['']
+    COLOR_RESET = ''
+
+    def color_idx(s):
+        return 0
+
 from iotlabcli.parser import common as common_parser
 
 from iotlabaggregator import connections, common, LOG_FMT
@@ -115,7 +131,8 @@ class SerialConnection(connections.Connection):  # pylint:disable=R0903,R0904
 
     def print_line(self, identifier, line):
         """ Print one line prefixed by id in format: """
-        self.logger.info("%s;%s", identifier, line)
+        self.logger.info("%s%s;%s%s", COLOR[color_idx(identifier) % len(COLOR)],
+                         identifier, line, COLOR_RESET)
 
 
 class SerialAggregator(connections.Aggregator):

--- a/iotlabaggregator/tests/serial_test.py
+++ b/iotlabaggregator/tests/serial_test.py
@@ -90,3 +90,13 @@ class TestSelectNodes(unittest.TestCase):
             ['-l', 'grenoble,m3,1', '-l', 'lille,wsn430,1'])
         nodes_list = serial.SerialAggregator.select_nodes(opts)
         self.assertEqual(['m3-1'], nodes_list)
+
+
+class TestColor(unittest.TestCase):
+
+    def test_has_color(self):
+        # pylint:disable=import-error
+        if serial.HAS_COLOR:
+            import colorama as _  # noqa
+        else:
+            self.assertRaises(ImportError, __import__, 'colorama')

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
                  'Environment :: Console',
                  'Topic :: Utilities', ],
     install_requires=['iotlabcli>=1.6.0'],
-    extra_require = {'color_serial': ['colorama>=0.3.7']}
+    extras_require={'color_serial': ['colorama>=0.3.7']},
 )

--- a/setup.py
+++ b/setup.py
@@ -65,4 +65,5 @@ setup(
                  'Environment :: Console',
                  'Topic :: Utilities', ],
     install_requires=['iotlabcli>=1.6.0'],
+    extra_require = {'color_serial': ['colorama>=0.3.7']}
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,py26,py27
+envlist = copying,{py26,py27}{,-color}
 
 [tox:jenkins]
 skip_missing_interpreters = True
@@ -20,6 +20,7 @@ deps=
     -rtests_utils/test-requirements.txt
     py26,py32: -rtests_utils/pylint-python-2.6_3.2.txt
 commands=
+    color: pip install -e .[color_serial]
     python setup.py nosetests
     python setup.py lint
     python setup.py pep8


### PR DESCRIPTION
This helps to visually differentiate the nodes a little bit.

It is an optional feature that can be activated by installing the [`colorama`](https://pypi.python.org/pypi/colorama) module, or by installing `iotlabaggregator` with the `color_serial` extra.
