### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: python
 
-matrix:
-  include:
-    - python: 2.6
-      env: TOXENV="py26,py26-color,cli"
-    - python: 2.7
-      env: TOXENV="copying,py27,py27-color,cli,coverage"
+python: 2.7
+
+env: TOXENV="copying,py27,py27-color,cli,coverage"
 
 before_install:
   - pip install tox

--- a/iotlabaggregator/common.py
+++ b/iotlabaggregator/common.py
@@ -114,7 +114,8 @@ def get_experiment_nodes(api, exp_id=None, hostname=None):
     # Check that the experiment is running
     state = experiment.get_experiment(api, exp_id, 'state')["state"]
     if state != 'Running':
-        raise RuntimeError("Experiment %u not running '%s'" % (exp_id, state))
+        raise RuntimeError("Experiment {} not running '{}'"
+                           .format(exp_id, state))
 
     # Check that the experiment is running
     resources = experiment.get_experiment(api, exp_id, 'resources')

--- a/iotlabaggregator/sniffer.py
+++ b/iotlabaggregator/sniffer.py
@@ -144,5 +144,5 @@ def main(args=None):
             aggregator.run()
             LOGGER.info('%u packets captured', aggregator.rx_packets)
     except (ValueError, RuntimeError) as err:
-        sys.stderr.write("%s\n" % err)
+        sys.stderr.write("{}\n".format(err))
         exit(1)

--- a/tests_utils/pylint-python-2.6.txt
+++ b/tests_utils/pylint-python-2.6.txt
@@ -1,4 +1,0 @@
-# Not using '2to3' anymore, pylint 1.4 breaks python 2.6 compatibility
-pylint<1.4.0
-logilab-common<0.63
-astroid<1.3.0

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -3,6 +3,5 @@ pytest-pep8
 pytest-cov
 mock
 setuptools-lint
-# issues with pep8 >= 1.6
-flake8==2.3.0
+flake8
 codecov>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,{py26,py27}{,-color}
+envlist = copying,py27{,-color}
 
 [testenv:copying]
 whitelist_externals = /bin/bash
@@ -15,10 +15,9 @@ commands=
 deps=
     git+git://github.com/iot-lab/cli-tools.git#egg=iotlabcli
     -rtests_utils/test-requirements.txt
-    py26: -rtests_utils/pylint-python-2.6.txt
 commands=
     color: pip install -e .[color_serial]
-    py.test
+    pytest
     python setup.py lint
     flake8
 


### PR DESCRIPTION
The [CI of this project](https://travis-ci.org/iot-lab/aggregation-tools/builds/310397790) is broken because pytest doesn't support python 2.6 anymore.

This is the good time to remove this dependency here as well.