### PR TITLE
fix error raised by pylint 1.8

### DIFF
--- a/iotlabaggregator/sniffer.py
+++ b/iotlabaggregator/sniffer.py
@@ -117,6 +117,7 @@ class SnifferAggregator(connections.Aggregator):
         help="Extract payload and no encapsulation. For foren6.")
 
     def __init__(self, nodes_list, outfd, raw=False, *args, **kwargs):
+        # pylint: disable=keyword-arg-before-vararg
         zep_pcap = zeptopcap.ZepPcap(outfd, raw)
         super(SnifferAggregator, self).__init__(
             nodes_list, pkt_handler=zep_pcap.write, *args, **kwargs)

--- a/iotlabaggregator/tests/serial_test.py
+++ b/iotlabaggregator/tests/serial_test.py
@@ -63,8 +63,7 @@ class TestSelectNodes(unittest.TestCase):
                  'site': 'grenoble'},
             ]}
             return resources
-        else:
-            self.fail()
+        return self.fail()
 
     @mock.patch('iotlabaggregator.common.HOSTNAME', 'grenoble')
     def test_no_args(self):


### PR DESCRIPTION
Pylint 1.8 is more strict now and new type of issues are raised:
* Keyword argument before variable positional arguments list in the definition of \_\_init\_\_ function: fixed by ignoring the issue because it can only be cleanly fixed with Python3
* Either all return statements in a function should return an expression, or none of them should: requires a straightforward change