### PR TITLE
zeptopcap: fix timestamp microseconds

### DIFF
--- a/iotlabaggregator/zeptopcap.py
+++ b/iotlabaggregator/zeptopcap.py
@@ -125,7 +125,7 @@ class ZepPcap():
         t_s = ntp_t[0] - self.NTP_JAN_1970
         t_us = (1000000 * ntp_t[1]) / self.NTP_SECONDS_FRAC
 
-        return t_s, t_us
+        return t_s, round(t_us)
 
     def _udp_header(self, pkt_len):
         """ Get UDP Header
@@ -189,7 +189,7 @@ class ZepPcap():
         4B - Actual lengt of packet: pkt_len
         """
 
-        hdr_struct = struct.Struct('=LfLL')
+        hdr_struct = struct.Struct('=LLLL')
         pcap_len = pkt_len
         pcap_hdr = hdr_struct.pack(t_s, t_us, pcap_len, pcap_len)
         return pcap_hdr


### PR DESCRIPTION
With Python3 support the timestamp microseconds (fraction of seconds) with float type is invalid and return Wireshark error:

```[Expert Info (Note/Sequence): Arrival Time: Fractional second -566447360 is invalid, the valid range is 0-1000000000]```

Below you can see that in the packet header the timestamp microseconds must have int type.

    typedef struct pcaprec_hdr_s {
            guint32 ts_sec;       /* timestamp seconds */
            guint32 ts_usec;      /* timestamp microseconds */
            guint32 incl_len;     /* number of octets of packet
                                     saved in file */
            guint32 orig_len;     /* actual length of packet */
    } pcaprec_hdr_t;